### PR TITLE
update possible regions

### DIFF
--- a/src/testing/infra/variables.tf
+++ b/src/testing/infra/variables.tf
@@ -31,7 +31,37 @@ variable "locustWorkerNodes" {
 variable "locustWorkerLocations" {
   description = "List of regions to deploy workers to in round robin fashion"
   type        = list(any)
-  default     = ["northeurope", "eastus2", "westeurope", "westus", "australiaeast", "francecentral", "southcentralus", "japaneast", "southindia", "brazilsouth", "germanywestcentral", "uksouth", "canadacentral", "eastus2", "uaenorth"]
+  default = [
+    "northeurope",
+    "eastus2",
+    "southeastasia",
+    "westeurope",
+    "westus",
+    "australiaeast",
+    "francecentral",
+    "southcentralus",
+    "japaneast",
+    "southindia",
+    "brazilsouth",
+    "germanywestcentral",
+    "uksouth",
+    "canadacentral",
+    "eastus",
+    "uaenorth",
+    "koreacentral",
+    "eastasia",
+    "australiasoutheast",
+    "canadaeast",
+    "centralindia",
+    "japanwest",
+    "norwayeast",
+    "switzerlandnorth",
+    "ukwest",
+    "centralus",
+    "northcentralus",
+    "westcentralus",
+    "westus2"
+  ]
 }
 
 variable "prefix" {


### PR DESCRIPTION
Updated (and tested) the list of possible regions to all Azure regions that currently support ACI based on this: https://azure.microsoft.com/en-us/global-infrastructure/services/?products=container-instances&regions=non-regional,us-east,us-east-2,us-central,us-north-central,us-south-central,us-west-central,us-west,us-west-2,south-africa-north,brazil-south,europe-north,europe-west,france-central,germany-west-central,central-india,south-india,west-india,japan-east,japan-west,korea-central,korea-south,norway-east,switzerland-north,uae-north,united-kingdom-south,united-kingdom-west,canada-central,canada-east,asia-pacific-east,asia-pacific-southeast,us-west-3,australia-central,australia-east,australia-southeast